### PR TITLE
skip evaluation in shape

### DIFF
--- a/halo2-ecc-circuit-lib/src/chips/ecc_chip.rs
+++ b/halo2-ecc-circuit-lib/src/chips/ecc_chip.rs
@@ -189,28 +189,50 @@ pub trait EccChipOps<C: CurveAffine, N: FieldExt> {
             Ok(curr_candidates.first().unwrap().clone())
         };
 
-        let mut acc = None;
+        let mut acc: Option<AssignedPoint<C, N>> = None;
+
+        let mut round_size = None;
 
         for wi in 0..windows_in_be[0].len() {
-            let mut inner_acc = None;
-            for pi in 0..points.len() {
-                let mut ci = pick_candidate(ctx, pi, &windows_in_be[pi][wi])?;
-                match inner_acc {
-                    None => inner_acc = Some(ci),
-                    Some(_inner_acc) => {
-                        let p = self.add(ctx, &mut ci, &_inner_acc)?;
-                        inner_acc = Some(p);
+            let mut get_inner = | round_size: Option<usize> | -> Result<(usize, AssignedPoint<C, N>), Error> {
+                match (round_size, ctx.in_shape_mode()) {
+                    (Some(rsize), true)  => {
+                        ctx.expand(rsize, acc.as_ref().unwrap().z.cell, acc.as_ref().unwrap().z.value)?;
+                        // Hack: acc is not accurate but we depends on overflow bits
+                        Ok((rsize, acc.clone().unwrap())) //Hack: In shape phase we dont care the result
+                    },
+                    _ => {
+                        let c = (*ctx.offset).clone();
+                        let mut inner_acc = None;
+                        for pi in 0..points.len() {
+                            let mut ci = pick_candidate(ctx, pi, &windows_in_be[pi][wi])?;
+                            match inner_acc {
+                                None => inner_acc = Some(ci),
+                                Some(_inner_acc) => {
+                                    let p = self.add(ctx, &mut ci, &_inner_acc)?;
+                                    inner_acc = Some(p);
+                                }
+                            }
+                        };
+                        let rsize = *ctx.offset - c;
+                        // Record the size of each around so that we can skip them in shape mode.
+                        Ok((rsize, inner_acc.unwrap()))
                     }
                 }
+            };
+
+            let (rsize, mut inner_acc) = get_inner(round_size)?;
+            if wi != 0 {
+                round_size = Some (rsize);
             }
 
             match acc {
-                None => acc = inner_acc,
+                None => acc = Some (inner_acc),
                 Some(mut _acc) => {
                     for _ in 0..CONFIG_WINDOW_SIZE {
                         _acc = self.double(ctx, &mut _acc)?;
                     }
-                    _acc = self.add(ctx, &mut inner_acc.unwrap(), &_acc)?;
+                    _acc = self.add(ctx, &mut inner_acc, &_acc)?;
                     acc = Some(_acc);
                 }
             }

--- a/halo2-ecc-circuit-lib/src/tests/five_native_ecc.rs
+++ b/halo2-ecc-circuit-lib/src/tests/five_native_ecc.rs
@@ -285,6 +285,7 @@ impl<C: CurveAffine> Circuit<C::ScalarExt> for TestFiveColumnNativeEccChipCircui
                 let base_offset = 0usize;
                 let mut aux = Context::new(region, base_offset);
                 let r = &mut aux;
+                r.in_shape_mode = base_gate.in_shape_mode(r)?;
                 let round = 1;
                 for _ in 0..round {
                     match self.test_case {

--- a/halo2-snark-aggregator-circuit/src/verify_circuit.rs
+++ b/halo2-snark-aggregator-circuit/src/verify_circuit.rs
@@ -378,6 +378,9 @@ impl<
                 let mut aux = Context::new(region, base_offset);
                 let ctx = &mut aux;
 
+                // Check context is used in shape layout or not
+                ctx.in_shape_mode = base_gate.in_shape_mode(ctx)?;
+
                 let circuit_proofs = self
                     .circuits
                     .iter()


### PR DESCRIPTION
This patch strongly assumes that

1. We using simple layouter
2. in Shape stage none fix or advice column are set
3. in setup and proof stage either advice or fix column are set